### PR TITLE
Fixed +3 chest timer for Black Rook Hold

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
                         <td class="table__cell"><span class="trn">Black Rook Hold</span>: <strong>39:00</strong></td>
                         <td class="table__cell">31:12 <span class="table__note">(7:48 <span class="trn">left on the timer</span>)</span>
                         </td>
-                        <td class="table__cell">23:25 <span class="table__note">(15:35 <span class="trn">left on the timer</span>)</span>
+                        <td class="table__cell">23:24 <span class="table__note">(15:36 <span class="trn">left on the timer</span>)</span>
                         </td>
                     </tr>
                     <tr class="table__row">


### PR DESCRIPTION
The time was off by 1 second, double checked that new time matches with http://www.wowhead.com/black-rook-hold-dungeon-strategy-guide