### PR TITLE
Change +2 chest from 355 to 350

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
 						<tr class="table__row">
 							<td class="table__cell">2</td>
 							<td class="table__cell">345</td>
-							<td class="table__cell">355</td>
+							<td class="table__cell">350</td>
 							<td class="table__cell">340</td>
 						</tr>
 						<tr class="table__row">


### PR DESCRIPTION
It was previously inaccurate and confirmed on an alt
This also corresponds to the table presented in:
https://www.wowhead.com/news=287076/mythic-weekly-chests-only-award-one-item-in-battle-for-azeroth