### PR TITLE
Updating Titan Residuum rewards table for Season 4 BFA Patch 8.3.

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,47 +580,47 @@
 						<tbody>
 							<tr class="table__row">
 								<td class="table__cell">10</td>
-								<td class="table__cell">17000</td>
+								<td class="table__cell">1700</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">11</td>
-								<td class="table__cell">17900</td>
+								<td class="table__cell">1790</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">12</td>
-								<td class="table__cell">18800</td>
+								<td class="table__cell">1880</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">13</td>
-								<td class="table__cell">19700</td>
+								<td class="table__cell">1970</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">14</td>
-								<td class="table__cell">20600</td>
+								<td class="table__cell">2060</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">15</td>
-								<td class="table__cell">21500</td>
+								<td class="table__cell">2150</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">16</td>
-								<td class="table__cell">22400</td>
+								<td class="table__cell">2240</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">17</td>
-								<td class="table__cell">23300</td>
+								<td class="table__cell">2330</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">18</td>
-								<td class="table__cell">24200</td>
+								<td class="table__cell">2420</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">19</td>
-								<td class="table__cell">25100</td>
+								<td class="table__cell">2510</td>
 							</tr>
 							<tr class="table__row">
 								<td class="table__cell">20</td>
-								<td class="table__cell">26000</td>
+								<td class="table__cell">2600</td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
Just an update to the Titan Residuum weekly chest rewards.

Source for table update:
https://us.forums.blizzard.com/en/wow/t/what-to-expect-in-visions-of-n%E2%80%99zoth-and-season-4/405981
> A Mythic +10 weekly chest will award 1700 Titan Residuum, with each additional level awarding 90 more Titan Residuum. For example, a Mythic + 15 will award 2150 Titan Residuum.