### PR TITLE
Updating dungeon instance timer levels with Mechagon Junkyard and Wor…

### DIFF
--- a/index.html
+++ b/index.html
@@ -487,6 +487,22 @@
 						<td class="table__cell">21:36 <span class="table__note">(14:24 <span class="trn">left on the timer</span>)</span>
 						</td>
 					</tr>
+                                        <tr class="table__row">
+                                                <td class="table__cell"><span class="trn">Mechagon: Junkyard</span></td>
+                                                <td class="table__cell"><strong>38:00</strong></td>
+                                                <td class="table__cell">30:24 <span class="table__note">(7:36 <span class="trn">left on the timer</span>)</span>
+                                                </td>
+                                                <td class="table__cell">22:38 <span class="table__note">(15:12 <span class="trn">left on the timer</span>)</span>
+                                                </td>
+                                        </tr>
+                                        <tr class="table__row">
+                                                <td class="table__cell"><span class="trn">Mechagon: Workshop</span></td>
+                                                <td class="table__cell"><strong>32:00</strong></td>
+                                                <td class="table__cell">25:36 <span class="table__note">(6:24 <span class="trn">left on the timer</span>)</span>
+                                                </td>
+                                                <td class="table__cell">19:12 <span class="table__note">(12:48 <span class="trn">left on the timer</span>)</span>
+                                                </td>
+                                        </tr>
 				</tbody>
 			</table>
 			<br>


### PR DESCRIPTION
Adding Mechagon Workshop and Junkyard dungeon timer levels to the table.

The times are taken from the in game API using the following command:
```
script print(C_ChallengeMode.GetMapUIInfo(369));
```

Screenshot:
![image](https://user-images.githubusercontent.com/8575685/73566186-17f41f00-4418-11ea-8748-95f4b880e659.png)

The format is `name`, `id`, `time in seconds`, `[...]`.

To verify against other dungeons Temple of Sethraliss is 36 minutes which is `36 * 60 = 2160` and Freehold is 33 minutes which is `33 * 60 = 1980`.

Please double check my math in case I failed at subtracting or something, haha, and thanks. 