### PR TITLE
Error in loot table

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@
 						<tr class="table__row">
 							<td class="table__cell">5</td>
 							<td class="table__cell">445</td>
-							<td class="table__cell">420</td>
+							<td class="table__cell">450</td>
 						</tr>
 						<tr class="table__row">
 							<td class="table__cell">6</td>


### PR DESCRIPTION
The mythic 5 level chest is reporting ilvl 420 gear while Blizz says its 450.
https://us.battle.net/support/en/article/54237