### PR TITLE
Update key level for affix based on dev notes

### DIFF
--- a/sections/en/4-affixes.html
+++ b/sections/en/4-affixes.html
@@ -30,8 +30,8 @@
 				</ul>
 			</div>
 			<div class="affixes-block">
-				<h3 class="title title--medium affixes-block__title">Level 4 affixes<br>
-					<div class="title__subtitle">(one affix will occur at +4 per week)</div>
+				<h3 class="title title--medium affixes-block__title">Level 7 affixes<br>
+					<div class="title__subtitle">(one affix will occur at +7 per week)</div>
 				</h3>
 				<ul class="affixes-list">
 					<li class="affixes-list__item-4-7 affix-bolstering">
@@ -62,8 +62,8 @@
 				</ul>
 			</div>
 			<div class="affixes-block">
-				<h3 class="title title--medium affixes-block__title">Level 7 affixes<br>
-					<div class="title__subtitle">(one affix will occur at +7 per week)</div>
+				<h3 class="title title--medium affixes-block__title">Level 14 affixes<br>
+					<div class="title__subtitle">(one affix will occur at +14 per week)</div>
 				</h3>
 				<ul class="affixes-list">
 					<li class="affixes-list__item-4-7 affix-explosive">
@@ -117,8 +117,8 @@
 					<thead class="table__head">
 						<tr class="table__row table__row--head">
 							<td class="table__cell">Baseline</td>
-							<td class="table__cell">2 (+4)</td>
-							<td class="table__cell">3 (+7)</td>
+							<td class="table__cell">2 (+7)</td>
+							<td class="table__cell">3 (+14)</td>
 							<td class="table__cell">Seasonal (+10)</td>
 						</tr>
 					</thead>


### PR DESCRIPTION
This change updates the key level that affixes are associated with based on the developer notes found here: https://www.wowhead.com/news/blizzard-responds-to-season-2-mythic-affix-feedback-and-upcoming-changes-332312. This wouldn't go into effect (if even implemented) until 10.1. 