### PR TITLE
Update and modernize text in the Loot section.

### DIFF
--- a/sections/en/8-loot.html
+++ b/sections/en/8-loot.html
@@ -131,10 +131,10 @@
 				<div class="table__description">
 					<p>The chest at the end of the run guarantees the <strong>GROUP</strong> two pieces of loot from the dungeon loot table, <span class="hard">even if you don't beat the timer</span>. One piece of loot will be at the item level that corresponds to the level of keystone you completed and one will be at a lower item level.</p><br>
 					<p>If you <span class="easy">beat the timer</span>, the group will be awarded two pieces of loot at the item level that corresponds to the level of the keystone you completed.</p>
-					<p>Example: Your group times a +15, two pieces of 398 loot drop in the end of run chest. Later, your group fails to time a +15. One piece of loot drops at 398 and one drops at 395 item level.</p>
+					<p>Example: Your group times a +15, two pieces of 424 loot drop in the end of run chest. Later, your group fails to time a +15. One piece of loot drops at 424 and one drops at 421 item level.</p>
 					<p>At reset, the Great Vault will have a keystone based on the highest level keystone run you completed the week before. However, the keystone will degrade if you do not continue to complete keystones at higher or equal levels to what you previously completed.</p>
 					<p>Example: You timed a +16 last week. This week at reset you get a +16 keystone from your chest. This week you don't time anything higher than a +16. Next week at reset you get a +15 key from the vault.</p>
-					<p>Gear that drops from keystone runs and from the Great Vault can be upgraded to a maximum item level of 415 using Valor. More info about Valor below.</p>
+					<p>Gear that drops from keystone runs and from the Great Vault can be upgraded to a maximum item level of 441 using Flightstones and Crests. More info about Flightstones and Crests below.</p>
 					<p class="hard">It is best to complete a <strong>+20</strong> every week to get the highest gear value from your weekly chest.</p>
 					<br>
 				</div>


### PR DESCRIPTION
The loot section still referred to Seasosn 1 item levels and Valor for upgrads.

This updates that text to refer to flightstonees and crests and tweaks the ilvls a bit to make them accurate.