### PR TITLE
Update loot upgrade paths for 10.1.5

### DIFF
--- a/sections/en/8-loot.html
+++ b/sections/en/8-loot.html
@@ -100,25 +100,25 @@
 							<td class="table__cell">16</td>
 							<td class="table__cell">424</td>
 							<td class="table__cell">441</td>
-							<td class="table__cell">Drake, Cannot upgrade</td>
+							<td class="table__cell">Drake, Aspect</td>
 						</tr>
 						<tr class="table__row">
 							<td class="table__cell">17</td>
 							<td class="table__cell">428</td>
 							<td class="table__cell">441</td>
-							<td class="table__cell">Wyrm, Cannot upgrade</td>
+							<td class="table__cell">Wyrm, Aspect</td>
 						</tr>
 						<tr class="table__row">
 							<td class="table__cell">18</td>
 							<td class="table__cell">428</td>
 							<td class="table__cell">444</td>
-							<td class="table__cell">Wyrm, Cannot upgrade</td>
+							<td class="table__cell">Wyrm, Aspect</td>
 						</tr>
 						<tr class="table__row">
 							<td class="table__cell">19</td>
 							<td class="table__cell">431</td>
 							<td class="table__cell">444</td>
-							<td class="table__cell">Wyrm, Cannot upgrade</td>
+							<td class="table__cell">Wyrm, Aspect</td>
 						</tr>
 						<tr class="table__row">
 							<td class="table__cell">20</td>


### PR DESCRIPTION
Vault gear can be upgraded to 447 using Aspect crests as long as it drops from the Vault at 441+ (https://www.wowhead.com/news/upgrade-441-gear-to-new-cap-of-447-item-level-on-new-myth-track-in-patch-10-1-5-333383)