### PR TITLE
Add back navigation, useful addons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -33,19 +33,15 @@ a:hover {
 }
 
 a {
-    color: #8be9fd;
-    transition: box-shadow .5s ease;
+    color: var(--green);
+    transition: border-bottom .3s ease;
     margin-bottom: -.05em;
     padding: .1vw;
-    box-shadow: 0 .75vh .25vh -.5vh transparent;
-    -moz-box-shadow: 0 .75vh .25vh -.5vh transparent;
-    -webkit-box-shadow: 0 .75vh .25vh -.5vh transparent
+    border-bottom: 1px solid transparent
 }
 
 a:hover {
-    box-shadow: 0 .75vh .25vh -.5vh #8be9fd;
-    -moz-box-shadow: 0 .75vh .25vh -.5vh #8be9fd;
-    -webkit-box-shadow: 0 .75vh .25vh -.5vh #8be9fd
+    border-bottom: 1px solid var(--green)
 }
 
 p {
@@ -239,6 +235,38 @@ ul+.title--medium {
     .arrow {
         font-size: 48px
     }
+}
+
+.jump-nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    padding: 12px 0;
+    background: var(--background);
+    box-shadow: 0 1px rgba(255, 255, 255, .15)
+}
+
+.jump-nav a {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: rgba(255, 255, 255, .4);
+    padding: 4px 0;
+    transition: color .2s ease;
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none
+}
+
+.jump-nav a:hover {
+    color: var(--green);
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none
 }
 
 .content-block {

--- a/sections/en/11-useful-stuff.html
+++ b/sections/en/11-useful-stuff.html
@@ -17,8 +17,14 @@
 				<ul>
 					<li><a href="https://www.curseforge.com/wow/addons/little-wigs">LittleWigs</a> - Requires <a href="https://www.curseforge.com/wow/addons/big-wigs">BigWigs Boss Mods.</a> A lightweight boss mod suite tailored for dungeons.</li>
 					<li><a href="https://www.curseforge.com/wow/addons/better-timeline">Better Timeline</a> - Gives a visual indication of upcoming encounter mechanics. Replaces the old <a href="https://wago.io/RaidAbilityTimeline">RaidAbilityTimeline</a> WeakAura.</li>
-					<li><a href="https://addons.wago.io/addons/platynator">Platynator</a> - Replaces the default nameplates with something ACTUALLY USEFUL! Use this if you're missing Plater, or just don't like the default nameplates.</li>
+					
 				</ul>
+				<h3 class="title title--small title--left">Generally addons to have</h3>
+				<ul>
+					<li><a href="https://www.curseforge.com/wow/addons/class-reminders">Class Reminders</a> - Comprehensive, highly configurable utility addon that tracks important class buffs, pet and stance state, consumables, external raid buffs, and resource bars. Replacement for a lot of the old class specific WeakAuras</li>
+					<li><a href="https://addons.wago.io/addons/platynator">Platynator</a> - Replaces the default nameplates with something ACTUALLY USEFUL! Use this if you're missing Plater, or just don't like the default nameplates.<br>
+						Really great with <a href="https://wago.io/zaiOOdVa1">Jundie's Platynator profile</a>.</li>
+
 				<h3 class="title title--small title--left">Keystone and group information</h3>
 				<ul>
 					<li><a href="https://www.curseforge.com/wow/addons/mythic-dungeon-tools">Mythic Dungeon Tools</a> - Plan out routes, then use a shareable interactive map to make sure your group is on the same page.</li>

--- a/sections/en/11-useful-stuff.html
+++ b/sections/en/11-useful-stuff.html
@@ -2,11 +2,17 @@
 			<h1 class="title title--large">Useful stuff</h1>
 			<div class="text-block">
 				<h2 class="title title--medium title--left">Addons</h2>
-				<p>This is not a definitive list of <em>THINGS YOU NEED</em>, but a list of addons that I find useful. </p>
+				<p>This is not a definitive list of <em>THINGS YOU NEED</em>, but a list of addons that I find useful. An good UI should feel comfortable for you to use and provide all the information that you deem useful.</p>
 				<br>
 				<h3 class="title title--small title--left">Addon Managers</h3>
 				<h3 class="title title--small title--left">A brief message about addon managers</h3>
 				<p>As someone who values their privacy online, I feel like it's important that I mention the Overwolf client is BAD and all of its privacy options are OPT-OUT by default, instead of OPT-IN. I encourage you to use an open source addon manager like <a href="https://wowup.io">wowup.io</a> or <a href="https://github.com/layday/instawow">instawow</a>. Just my two cents.</p>
+				<h3 class="title title--small title--left">Generally good addons to have</h3>
+				<ul>
+					<li><a href="https://www.curseforge.com/wow/addons/class-reminders">Class Reminders</a> - Comprehensive, highly configurable utility addon that tracks important class buffs, pet and stance state, consumables, external raid buffs, and resource bars. Replacement for a lot of the old class specific WeakAuras</li>
+					<li><a href="https://addons.wago.io/addons/platynator">Platynator</a> - Replaces the default nameplates with something ACTUALLY USEFUL! Use this if you're missing Plater, or just don't like the default nameplates.<br>
+						Really great with <a href="https://wago.io/zaiOOdVa1">Jundie's Platynator profile</a>.</li>
+				</ul>
 				<h3 class="title title--small title--left">Timers</h3>
 				<ul>
 					<li><a href="https://www.curseforge.com/wow/addons/warpdeplete">WarpDeplete</a> - Nice timer. It's probably the one you see streamers use.</li>
@@ -17,13 +23,8 @@
 				<ul>
 					<li><a href="https://www.curseforge.com/wow/addons/little-wigs">LittleWigs</a> - Requires <a href="https://www.curseforge.com/wow/addons/big-wigs">BigWigs Boss Mods.</a> A lightweight boss mod suite tailored for dungeons.</li>
 					<li><a href="https://www.curseforge.com/wow/addons/better-timeline">Better Timeline</a> - Gives a visual indication of upcoming encounter mechanics. Replaces the old <a href="https://wago.io/RaidAbilityTimeline">RaidAbilityTimeline</a> WeakAura.</li>
-					
+					<li><a href="https://www.curseforge.com/wow/addons/keystone-polaris">Keystone Polaris</a> - Replaces the <a href="https://wago.io/4pHPrk9NM">WeakAura (RIP)</a> (same developer btw) that showed the required percentage you should have before the end of a section in a dungeon (e.g. jumping into a pit or something where you can't easily go back). There are other good features, too!</li>
 				</ul>
-				<h3 class="title title--small title--left">Generally addons to have</h3>
-				<ul>
-					<li><a href="https://www.curseforge.com/wow/addons/class-reminders">Class Reminders</a> - Comprehensive, highly configurable utility addon that tracks important class buffs, pet and stance state, consumables, external raid buffs, and resource bars. Replacement for a lot of the old class specific WeakAuras</li>
-					<li><a href="https://addons.wago.io/addons/platynator">Platynator</a> - Replaces the default nameplates with something ACTUALLY USEFUL! Use this if you're missing Plater, or just don't like the default nameplates.<br>
-						Really great with <a href="https://wago.io/zaiOOdVa1">Jundie's Platynator profile</a>.</li>
 
 				<h3 class="title title--small title--left">Keystone and group information</h3>
 				<ul>

--- a/sections/en/3-nav.html
+++ b/sections/en/3-nav.html
@@ -1,0 +1,9 @@
+
+		<nav class="jump-nav">
+			<a href="#affixes-div">Affixes</a>
+			<a href="#keystone-upgrade">Keystones</a>
+			<a href="#the-great-vault">Great Vault</a>
+			<a href="#loot-stuff">Loot</a>
+			<a href="#mplus-rating">Rating</a>
+			<a href="#useful-stuff">Useful Stuff</a>
+		</nav>


### PR DESCRIPTION
Add a sticky navigation header to replace the jank menu I removed a long time ago.

Adding some more useful addons and shuffling the order around. Maybe I should do cards like I have the affixes for addons? Kinda just looks like a blob of text rn.

